### PR TITLE
Restore sbt run behaviour

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,3 +46,5 @@ addCommandAlias(
 Universal / mappings ++= directory("src/main/resources/pages")
 dockerEnvVars   := Map("PORT" -> "$PORT", "HOST" -> "$HOST", "INDEX_PATH" -> "$INDEX_PATH")
 dockerBaseImage := "openjdk:17"
+
+fork := true


### PR DESCRIPTION
`sbt run` was not working anymore, leaving immediatly to the shell.

This fixes this behaviour and allows to run locally the pointing poker with `sbt run`