### PR TITLE
Add more granularity for higher estimation values: split 100 between 55 and 89

### DIFF
--- a/src/main/resources/pages/index.html
+++ b/src/main/resources/pages/index.html
@@ -315,7 +315,7 @@
       data: {
         roomId: localStorage.getItem("roomId"),
         wsConnection: undefined,
-        estimationValues: ['0','0.5','1','2','3','5','8','13','21','34','100','?'],
+        estimationValues: ['0','0.5','1','2','3','5','8','13','21','34','55','89','?'],
         creating: true,
         joining: false,
         editing: false,


### PR DESCRIPTION

The pointing poker is also used for release planning, during full features are estimated. It's expected for them to not fit inside a sprint, but it's still need to differentiate between higher story points.
It's also relevant considering that some teams have a story points scale shifted toward higher values (read 13 or 21 velocity for a single person for a sprint)